### PR TITLE
Adjust packages and extensions in order to run on PHP 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,17 @@
 #   docker build -f Dockerfile-dev -t api-tools .
 #   docker run -it -p "8080:80" -v $PWD:/var/www api-tools
 #
-FROM php:7.3-apache
+FROM php:8.0-apache
 
 RUN apt-get update \
- && apt-get install -y git libzip-dev \
+ && apt-get install -y git libzip-dev libicu-dev \
  && docker-php-ext-install zip \
+ && docker-php-ext-configure intl \
+ && docker-php-ext-install intl \
  && a2enmod rewrite \
  && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf \
  && mv /var/www/html /var/www/public \
- && curl -sS https://getcomposer.org/installer \
-  | php -- --install-dir=/usr/local/bin --filename=composer \
+ && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
  && echo "AllowEncodedSlashes On" >> /etc/apache2/apache2.conf
 
 WORKDIR /var/www


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

I've seen that the project skeleton can't run on PHP-8.0 as reported here #44 
Since I also have the need to run a new project on PHP-8.0 I've adjusted the composer packages and Dockerfile in order to run on that version.
Hope you find it usefull

