### PR TITLE
Update provisioning tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@
 #   docker build -f Dockerfile-dev -t api-tools .
 #   docker run -it -p "8080:80" -v $PWD:/var/www api-tools
 #
-FROM composer:2.3.5 AS get-composer
-FROM php:8.0-apache
+FROM composer:2 AS get-composer
+FROM php:8.2-apache
 
 RUN apt-get update \
  && apt-get install -y git libzip-dev libicu-dev \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,8 +5,11 @@ VAGRANTFILE_API_VERSION = '2'
 
 @script = <<SCRIPT
 # Install dependencies
+LC_ALL=C.UTF-8
 apt-get update
-apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0
+apt-get install software-properties-common ca-certificates lsb-release apt-transport-https
+add-apt-repository ppa:ondrej/php
+apt-get install -y apache2 git curl php8.2 php8.2-bcmath php8.2-bz2 php8.2-cli php8.2-curl php8.2-intl php8.2-json php8.2-mbstring php8.2-opcache php8.2-soap php8.2-sqlite3 php8.2-xml php8.2-xsl php8.2-zip libapache2-mod-php8.2
 
 # Configure Apache
 echo "<VirtualHost *:80>
@@ -44,7 +47,7 @@ echo "** [Laminas] Visit http://localhost:8080 in your browser for to view the a
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'bento/ubuntu-16.04'
+  config.vm.box = 'bento/ubuntu-22.04'
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.synced_folder '.', '/var/www', owner: "www-data", group: "www-data"
   config.vm.provision 'shell', inline: @script

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ LC_ALL=C.UTF-8
 apt-get update
 apt-get install software-properties-common ca-certificates lsb-release apt-transport-https
 add-apt-repository ppa:ondrej/php
-apt-get install -y apache2 git curl php8.2 php8.2-bcmath php8.2-bz2 php8.2-cli php8.2-curl php8.2-intl php8.2-json php8.2-mbstring php8.2-opcache php8.2-soap php8.2-sqlite3 php8.2-xml php8.2-xsl php8.2-zip libapache2-mod-php8.2
+apt-get install -y apache2 git curl php8.2 php8.2-bcmath php8.2-bz2 php8.2-cli php8.2-curl php8.2-intl php8.2-mbstring php8.2-opcache php8.2-soap php8.2-sqlite3 php8.2-xml php8.2-xsl php8.2-zip libapache2-mod-php8.2
 
 # Configure Apache
 echo "<VirtualHost *:80>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

This patch updates the shipped provisioning scripts/tools.

- Bumps Vagrantfile:
  - Use Ubuntu 22.04
  - Use Sury repo for PHP
  - Install PHP 8.2
- Bumps Dockerfile
  - Use latest Composer 2 version
  - Use PHP 8.2 image
